### PR TITLE
Fix fan off appearance to match other tiles

### DIFF
--- a/themes/material_rounded.yaml
+++ b/themes/material_rounded.yaml
@@ -436,7 +436,7 @@ Material Rounded No Mod:
 
             # Inconsistent tile card CSS
             state-alarm_control_panel-disarmed-color: rgb(72, 74, 78)
-            state-fan-off-color: var(--disabled-color)
+            state-fan-off-color: var(--tile-color)
             state-climate-off-color: rgb(72, 74, 78)
 
         light:

--- a/themes/material_rounded.yaml
+++ b/themes/material_rounded.yaml
@@ -29,7 +29,7 @@ Material Rounded:
 
             # Inconsistent tile card CSS
             state-alarm_control_panel-disarmed-color: rgb(72, 74, 78)
-            state-fan-off-color: var(--disabled-color)
+            state-fan-off-color: var(--tile-color)
             state-climate-off-color: rgb(72, 74, 78)
 
         light:


### PR DESCRIPTION
When using a fan entity in a tile, the disabled colors were set for the tile instead of the normal colors for an entity that is currently off.  This patch fixes this issue.

Current:
![Screenshot 2024-03-04 180328](https://github.com/Nerwyn/material-rounded-theme/assets/9072542/c9efc805-bf21-4650-b080-132a56811778)

Fix:
![Screenshot 2024-03-04 180442](https://github.com/Nerwyn/material-rounded-theme/assets/9072542/6837d646-21b2-4425-b5e6-bb2e332e0cd9)

